### PR TITLE
Add user preferences tests and integration

### DIFF
--- a/__tests__/unit/execute-snipe.test.tsx
+++ b/__tests__/unit/execute-snipe.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { usePatternSniper } from '@/src/hooks/use-pattern-sniper'
+
+describe('executeSnipe', () => {
+  it('uses user preferences for snipe parameters', async () => {
+    const prefs = {
+      userId: 'user',
+      defaultBuyAmountUsdt: 75,
+      maxConcurrentSnipes: 1,
+      takeProfitLevels: { level1: 5, level2: 10, level3: 15, level4: 25 },
+      defaultTakeProfitLevel: 3,
+      stopLossPercent: 6,
+      riskTolerance: 'medium',
+      readyStatePattern: [2,2,4],
+      targetAdvanceHours: 3,
+      calendarPollIntervalSeconds: 300,
+      symbolsPollIntervalSeconds: 30,
+      selectedExitStrategy: 'balanced',
+      customExitStrategy: undefined,
+      autoBuyEnabled: true,
+      autoSellEnabled: true,
+      autoSnipeEnabled: true,
+    }
+
+    const fetchMock = vi.fn((url: string, options?: RequestInit) => {
+      if (url.startsWith('/api/user-preferences')) {
+        return Promise.resolve({ ok: true, json: async () => prefs })
+      }
+      if (url.startsWith('/api/snipe-targets')) {
+        return Promise.resolve({ ok: true, json: async () => ({ data: { id: 1 } }) })
+      }
+      if (url.startsWith('/api/mexc/trade')) {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, order: { price: 1, quantity: 1, orderId: '1', status: 'done' } }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: [] }) })
+    })
+    global.fetch = fetchMock as any
+
+    const client = new QueryClient()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => usePatternSniper(), { wrapper })
+
+    const target = {
+      symbol: 'TEST',
+      projectName: 'Test',
+      launchTime: new Date(),
+      orderParameters: { quantity: '10' },
+      vcoinId: 'v1',
+      confidence: 0.9,
+      discoveredAt: new Date(),
+      hoursAdvanceNotice: 1,
+    } as any
+
+    await act(async () => {
+      await result.current.executeSnipe(target, 'user')
+    })
+
+    const call = fetchMock.mock.calls.find(c => c[0] === '/api/snipe-targets')
+    expect(call).toBeTruthy()
+    const body = JSON.parse((call as any)[1].body as string)
+    expect(body.positionSizeUsdt).toBe(prefs.defaultBuyAmountUsdt)
+    expect(body.takeProfitLevel).toBe(prefs.defaultTakeProfitLevel)
+    expect(body.stopLossPercent).toBe(prefs.stopLossPercent)
+  })
+})

--- a/__tests__/unit/user-preferences.test.ts
+++ b/__tests__/unit/user-preferences.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getUserPreferences, type UserPreferences } from '@/src/lib/user-preferences'
+
+describe('getUserPreferences', () => {
+  const userId = 'test-user'
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns parsed preferences when request succeeds', async () => {
+    const prefs: UserPreferences = {
+      userId,
+      defaultBuyAmountUsdt: 50,
+      maxConcurrentSnipes: 1,
+      takeProfitLevels: { level1: 5, level2: 10, level3: 15, level4: 25 },
+      defaultTakeProfitLevel: 2,
+      stopLossPercent: 4,
+      riskTolerance: 'medium',
+      readyStatePattern: [2,2,4],
+      targetAdvanceHours: 3,
+      calendarPollIntervalSeconds: 300,
+      symbolsPollIntervalSeconds: 30,
+      selectedExitStrategy: 'balanced',
+      customExitStrategy: undefined,
+      autoBuyEnabled: true,
+      autoSellEnabled: true,
+      autoSnipeEnabled: true,
+    }
+
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => prefs })
+
+    const result = await getUserPreferences(userId)
+    expect(result).toEqual(prefs)
+    expect(fetch).toHaveBeenCalledWith(`/api/user-preferences?userId=${userId}`)
+  })
+
+  it('returns null when request fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false })
+
+    const result = await getUserPreferences(userId)
+    expect(result).toBeNull()
+  })
+
+  it('returns null on network error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'))
+
+    const result = await getUserPreferences(userId)
+    expect(result).toBeNull()
+  })
+})

--- a/src/hooks/use-pattern-sniper.ts
+++ b/src/hooks/use-pattern-sniper.ts
@@ -1,3 +1,4 @@
+import { getUserPreferences } from "@/src/lib/user-preferences";
 import {
   type CalendarEntry,
   type OrderParameters as SchemaOrderParameters,
@@ -256,6 +257,11 @@ export const usePatternSniper = () => {
 
     const actualUserId = userId || "anonymous";
 
+    const prefs = await getUserPreferences(actualUserId);
+    const positionSizeUsdt = prefs?.defaultBuyAmountUsdt ?? 100;
+    const takeProfitLevel = prefs?.defaultTakeProfitLevel ?? 2;
+    const stopLossPercent = prefs?.stopLossPercent ?? 5.0;
+
     try {
       // 1. Create snipe target entry in database for tracking
       const snipeTargetResponse = await fetch("/api/snipe-targets", {
@@ -268,9 +274,9 @@ export const usePatternSniper = () => {
           vcoinId: target.vcoinId,
           symbolName: target.symbol,
           entryStrategy: "market",
-          positionSizeUsdt: 100, // TODO: Get from user preferences
-          takeProfitLevel: 2, // Default to balanced
-          stopLossPercent: 5.0, // Default stop loss
+          positionSizeUsdt,
+          takeProfitLevel,
+          stopLossPercent,
           status: "executing",
           priority: 1,
           targetExecutionTime: Math.floor(Date.now() / 1000),

--- a/src/lib/user-preferences.ts
+++ b/src/lib/user-preferences.ts
@@ -1,0 +1,38 @@
+export interface UserPreferences {
+  userId: string;
+  defaultBuyAmountUsdt: number;
+  maxConcurrentSnipes: number;
+  takeProfitLevels: {
+    level1: number;
+    level2: number;
+    level3: number;
+    level4: number;
+    custom?: number;
+  };
+  defaultTakeProfitLevel: number;
+  stopLossPercent: number;
+  riskTolerance: "low" | "medium" | "high";
+  readyStatePattern: [number, number, number];
+  targetAdvanceHours: number;
+  calendarPollIntervalSeconds: number;
+  symbolsPollIntervalSeconds: number;
+  selectedExitStrategy: string;
+  customExitStrategy?: unknown;
+  autoBuyEnabled: boolean;
+  autoSellEnabled: boolean;
+  autoSnipeEnabled: boolean;
+}
+
+export async function getUserPreferences(userId: string): Promise<UserPreferences | null> {
+  try {
+    const response = await fetch(`/api/user-preferences?userId=${encodeURIComponent(userId)}`);
+    if (!response.ok) {
+      return null;
+    }
+    const prefs = await response.json();
+    return prefs as UserPreferences;
+  } catch (error) {
+    console.error("[getUserPreferences] Failed to fetch preferences:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `getUserPreferences` helper
- utilize user preferences when executing snipes
- add unit tests for preference retrieval
- add hook test ensuring executeSnipe uses fetched preferences

## Testing
- `bun run test`
- `bun run lint:all` *(fails: Some errors were emitted while applying fixes)*
- `bun run type-check`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_684aa9b39d3883308e0a87e75ab83f45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User trading preferences are now automatically applied when executing snipe operations, allowing for personalized position size, take profit, and stop loss settings.
- **Tests**
  - Added unit tests to verify correct application of user preferences during snipe execution and to ensure robust handling of user preferences retrieval, including error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->