### PR TITLE
Add helper to fetch user preferences

### DIFF
--- a/src/hooks/use-user-preferences.ts
+++ b/src/hooks/use-user-preferences.ts
@@ -30,6 +30,20 @@ export interface UserTradingPreferences {
   autoSnipeEnabled: boolean; // Auto-snipe by default
 }
 
+// Helper to fetch user preferences without React hooks
+export async function getUserPreferences(userId: string): Promise<UserTradingPreferences | null> {
+  try {
+    const response = await fetch(`/api/user-preferences?userId=${encodeURIComponent(userId)}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch user preferences: ${response.statusText}`);
+    }
+    return (await response.json()) as UserTradingPreferences;
+  } catch (error) {
+    console.error("[getUserPreferences] Failed to fetch preferences:", error);
+    return null;
+  }
+}
+
 // Hook to get user preferences
 export function useUserPreferences(userId: string) {
   return useQuery({


### PR DESCRIPTION
## Summary
- provide `getUserPreferences` utility for fetching preferences outside React
- apply the helper when executing snipes in `use-pattern-sniper`

## Testing
- `make test`
- `make lint` *(fails: some Biome warnings/errors)*
- `bun run type-check`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684aa9ae584c833089eeea0d943f46b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Snipe orders now automatically use your saved trading preferences (such as position size, take profit, and stop loss) if available, providing a more personalized experience.
- **Bug Fixes**
  - Improved handling when user preferences cannot be loaded, ensuring snipe orders still proceed with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->