### PR TITLE
Add login E2E tests

### DIFF
--- a/tests/e2e/auth-credentials-login.spec.ts
+++ b/tests/e2e/auth-credentials-login.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.TEST_BASE_URL || 'http://localhost:3008';
+const EMAIL = process.env.AUTH_EMAIL || 'ryan@ryanlisse.com';
+const PASSWORD = process.env.AUTH_PASSWORD || 'Testing2025!';
+
+test.describe('Authentication with provided credentials', () => {
+  test('should sign in and reach dashboard', async ({ page }) => {
+    await page.goto(`${BASE_URL}/auth`);
+    await page.waitForLoadState('networkidle');
+
+    // ensure we are on login form
+    const loginToggle = page.locator('text=Sign in');
+    if (await loginToggle.count()) {
+      await loginToggle.first().click({ timeout: 2000 }).catch(() => {});
+    }
+
+    await page.fill('input[name="email"], #email', EMAIL);
+    await page.fill('input[name="password"], #password', PASSWORD);
+    await page.click('button[type="submit"]');
+
+    await page.waitForURL('**/dashboard', { timeout: 15000 });
+    expect(page.url()).toMatch(/\/dashboard$/);
+    await expect(page.locator('text=Dashboard')).toBeVisible();
+  });
+});

--- a/tests/e2e/stagehand-critical-flows.spec.ts
+++ b/tests/e2e/stagehand-critical-flows.spec.ts
@@ -1,0 +1,38 @@
+import { Stagehand } from '@browserbasehq/stagehand';
+import { expect, test } from '@playwright/test';
+import { z } from 'zod';
+import StagehandConfig from '../../stagehand.config.unified';
+
+const EMAIL = process.env.AUTH_EMAIL || 'ryan@ryanlisse.com';
+const PASSWORD = process.env.AUTH_PASSWORD || 'Testing2025!';
+
+test.describe('Critical flow smoke test (Stagehand)', () => {
+  let stagehand: Stagehand;
+
+  test.beforeAll(async () => {
+    stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+  });
+
+  test.afterAll(async () => {
+    if (stagehand) await stagehand.close();
+  });
+
+  test('login and verify dashboard access', async () => {
+    const page = stagehand.page;
+    await page.goto('http://localhost:3008');
+    await page.act('Click the Sign In button');
+    await page.waitForURL('**/auth');
+
+    await page.act(`Fill in the email field with "${EMAIL}"`);
+    await page.act(`Fill in the password field with "${PASSWORD}"`);
+    await page.act('Submit the sign in form');
+
+    await page.waitForURL('**/dashboard');
+    const result = await page.extract({
+      instruction: 'Confirm user landed on dashboard',
+      schema: z.object({ dashboard: z.boolean() })
+    });
+    expect(result.dashboard).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test for logging in with provided credentials
- add Stagehand smoke test covering login & dashboard

## Testing
- `make lint` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*
- `make type-check` *(fails: numerous TypeScript errors)*
- `make test` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6866426175888330b22f4bbf3c7c2c1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests to verify successful authentication and dashboard access.
  * Introduced a critical flow smoke test to automate and validate the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->