### PR TITLE
Document Stagehand test credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -232,6 +232,10 @@ AUTO_SNIPING_ENABLED="true"   # Default: enabled (only set to "false" to disable
 # DEBUG="mexc-api:*"            # Enable debug logging
 # VERBOSE_LOGGING="true"        # Enable verbose logging
 
+# Optional credentials for automated E2E tests
+TEST_USER_EMAIL=
+TEST_USER_PASSWORD=
+
 # ==============================================================================
 # 📝 SETUP INSTRUCTIONS
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ DATABASE_URL=sqlite:///./mexc_sniper.db
 # Optional - Workflow Orchestration (auto-generated if not provided)
 # INNGEST_SIGNING_KEY=your_signing_key
 # INNGEST_EVENT_KEY=your_event_key
+# Optional credentials for automated E2E tests
+TEST_USER_EMAIL=your_test_email@example.com
+TEST_USER_PASSWORD=your_test_password
 ```
 
 ### 2.1. Kinde Authentication Setup

--- a/docs/testing/STAGEHAND_E2E_TESTING.md
+++ b/docs/testing/STAGEHAND_E2E_TESTING.md
@@ -71,6 +71,9 @@ KINDE_POST_LOGIN_REDIRECT_URL=http://localhost:3008/dashboard
 # Test environment
 PLAYWRIGHT_TEST=true
 NODE_ENV=test
+# Optional credentials for automated E2E tests
+TEST_USER_EMAIL=your_test_email@example.com
+TEST_USER_PASSWORD=your_test_password
 ```
 
 ### Stagehand Configuration


### PR DESCRIPTION
## Summary
- add TEST_USER_EMAIL and TEST_USER_PASSWORD placeholders
- document these env variables in Stagehand guide and README

## Testing
- `make lint`
- `make type-check` *(fails: Cannot find module '@supabase/supabase-js')*
- `make test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6866437d0c548330a2d4fba5049ff65e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about two new optional environment variables, `TEST_USER_EMAIL` and `TEST_USER_PASSWORD`, for automated end-to-end testing in the environment configuration example, README, and E2E testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->