### PR TITLE
Add auth API 500 regression tests

### DIFF
--- a/tests/integration/auth-endpoints.test.ts
+++ b/tests/integration/auth-endpoints.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { spawn } from 'child_process'
+
+const PORT = 3103
+const BASE_URL = `http://localhost:${PORT}`
+let server: ReturnType<typeof spawn>
+
+async function startServer() {
+  return new Promise<void>((resolve) => {
+    server = spawn('npx', ['next', 'dev', '-p', PORT.toString()])
+    server.stdout.on('data', (data) => {
+      if (data.toString().includes('Ready')) {
+        resolve()
+      }
+    })
+  })
+}
+
+async function stopServer() {
+  if (server) server.kill('SIGINT')
+}
+
+beforeAll(async () => {
+  await startServer()
+}, 30000)
+
+afterAll(async () => {
+  await stopServer()
+})
+
+describe('Auth API endpoints return 500', () => {
+  it('GET /api/auth/session', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/session`)
+    expect(res.status).toBe(500)
+  })
+
+  it('POST /api/auth/signout', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/signout`, { method: 'POST' })
+    expect(res.status).toBe(500)
+  })
+
+  it('GET /api/auth/callback', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/callback?code=test`)
+    expect(res.status).toBe(500)
+  })
+
+  it('GET /api/auth/supabase-session', async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/supabase-session`)
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary
- create integration tests to reproduce `/api/auth/*` 500s

## Testing
- `make lint` *(fails: cannot find module '@biomejs/cli-linux-x64/biome')*
- `make type-check` *(fails: cannot find module '@supabase/supabase-js' et al.)*
- `make test` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6866daba1a7083308ff3c12f5c0f03ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new integration tests to verify authentication API endpoints, ensuring they respond as expected under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->