### PR TITLE
Fix TS1320 await and WebSocket emitter

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -183,21 +183,17 @@ function createPostgresClient() {
 function createMockDatabase() {
   // Create a thenable mock that resolves to empty array
   const createThenable = (result: any[] = []) => {
-    const thenable = {
-      then: (resolve: any) => resolve(result),
-      catch: (reject: any) => reject,
-      finally: (fn: any) => fn(),
-      // Add common query methods that return themselves
-      where: () => thenable,
-      orderBy: () => thenable,
-      limit: () => thenable,
-      select: () => thenable,
-      from: () => thenable,
-      set: () => thenable,
-      values: () => thenable,
-      returning: () => thenable,
-    };
-    return thenable;
+    const promise: any = Promise.resolve(result);
+    // Attach common query builder stubs that return the promise for chaining
+    promise.where = () => promise;
+    promise.orderBy = () => promise;
+    promise.limit = () => promise;
+    promise.select = () => promise;
+    promise.from = () => promise;
+    promise.set = () => promise;
+    promise.values = () => promise;
+    promise.returning = () => promise;
+    return promise;
   };
 
   return {


### PR DESCRIPTION
## Summary
- fix mock DB to return real Promises for type checks
- replace Node.js EventEmitter in WebSocket client with a browser-friendly emitter

## Testing
- `make lint` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*
- `make type-check` *(fails: many missing modules & type errors)*
- `make test` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*
- `make build` *(fails: Next.js module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866e20fa3208330b69bdf0607faffe4