### PR TITLE
Add paper trading toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ MEXC_SECRET_KEY="your-mexc-secret-key"
 MEXC_BASE_URL="https://api.mexc.com"
 MEXC_WEBSOCKET_URL="wss://wbs.mexc.com/ws"
 
+# Toggle global paper trading mode
+PAPER_TRADING_MODE=true
+
 # MEXC API Performance Settings (Advanced)
 # MEXC_TIMEOUT="30000"
 # MEXC_RETRY_COUNT="3"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ MEXC_API_KEY=your_mexc_api_key
 MEXC_SECRET_KEY=your_mexc_secret_key
 MEXC_BASE_URL=https://api.mexc.com
 
+# Enable paper trading (no real orders)
+PAPER_TRADING_MODE=true
+
 # Database Configuration
 # Option 1: Local SQLite (default for development)
 DATABASE_URL=sqlite:///./mexc_sniper.db

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,6 +17,8 @@ import { DashboardLayout } from "@/src/components/dashboard-layout";
 import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { Card, CardContent } from "@/src/components/ui/card";
+import { Label } from "@/src/components/ui/label";
+import { Switch } from "@/src/components/ui/switch";
 import {
   Tabs,
   TabsContent,
@@ -118,6 +120,11 @@ export default function SettingsPage() {
     autoSellEnabled: preferences?.autoSellEnabled ?? true,
   });
 
+  // Paper trading mode
+  const [paperTradingEnabled, setPaperTradingEnabled] = useState(
+    settingsStatus?.executionSettings.paperTradingMode ?? true
+  );
+
   // Initialize state from preferences
   useEffect(() => {
     if (preferences) {
@@ -137,6 +144,30 @@ export default function SettingsPage() {
       });
     }
   }, [preferences]);
+
+  // Initialize paper trading state from execution settings
+  useEffect(() => {
+    if (settingsStatus) {
+      setPaperTradingEnabled(settingsStatus.executionSettings.paperTradingMode);
+    }
+  }, [settingsStatus]);
+
+  const handlePaperTradingToggle = async (enabled: boolean) => {
+    setPaperTradingEnabled(enabled);
+    try {
+      await updateExecutionSettings({ paperTradingMode: enabled });
+      toast({
+        title: enabled ? "Paper trading enabled" : "Paper trading disabled",
+      });
+    } catch (error) {
+      toast({
+        title: "Error updating paper trading mode",
+        description:
+          error instanceof Error ? error.message : "Failed to update setting",
+        variant: "destructive",
+      });
+    }
+  };
 
   // Handle saving editable take-profit table
   const _handleSaveMultiLevelTakeProfit = async (levels: any[]) => {
@@ -399,6 +430,25 @@ export default function SettingsPage() {
                 System Check
               </Button>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Paper Trading Toggle */}
+        <Card>
+          <CardContent className="p-4 flex items-center justify-between">
+            <div className="space-y-1">
+              <Label htmlFor="paper-trading" className="font-medium">
+                Paper Trading Mode
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Simulate trades without real orders
+              </p>
+            </div>
+            <Switch
+              id="paper-trading"
+              checked={paperTradingEnabled}
+              onCheckedChange={handlePaperTradingToggle}
+            />
           </CardContent>
         </Card>
 

--- a/src/services/trading/consolidated/core-trading/base-service.ts
+++ b/src/services/trading/consolidated/core-trading/base-service.ts
@@ -129,9 +129,15 @@ export class CoreTradingService extends BrowserCompatibleEventEmitter {
     super();
 
     // Validate and set configuration
+    const paperTradingFlag =
+      (process.env.MEXC_PAPER_TRADING ?? process.env.PAPER_TRADING_MODE) !==
+      "false";
+
     this.config = validateConfig({
       apiKey: process.env.MEXC_API_KEY || "",
       secretKey: process.env.MEXC_SECRET_KEY || "",
+      enablePaperTrading: paperTradingFlag,
+      paperTradingMode: paperTradingFlag,
       ...config,
     });
 

--- a/src/services/trading/enhanced-mexc-config.ts
+++ b/src/services/trading/enhanced-mexc-config.ts
@@ -150,7 +150,9 @@ export class EnhancedMexcConfig {
       orderTimeout: parseInt(process.env.MEXC_ORDER_TIMEOUT || "30000"),
       maxSlippage: parseFloat(process.env.MEXC_MAX_SLIPPAGE || "2"),
       retryAttempts: parseInt(process.env.MEXC_RETRY_ATTEMPTS || "3"),
-      paperTradingMode: process.env.MEXC_PAPER_TRADING === "true",
+      paperTradingMode:
+        (process.env.MEXC_PAPER_TRADING ?? process.env.PAPER_TRADING_MODE) !==
+        "false",
 
       // Rate Limiting
       requestsPerSecond: parseInt(process.env.MEXC_REQUESTS_PER_SECOND || "10"),
@@ -637,7 +639,9 @@ export function getEnvironmentConfig(): Partial<MexcTradingConfig> {
       passphrase: process.env.MEXC_PASSPHRASE || "",
       sandbox: process.env.MEXC_SANDBOX === "true",
     },
-    paperTradingMode: process.env.MEXC_PAPER_TRADING === "true",
+    paperTradingMode:
+      (process.env.MEXC_PAPER_TRADING ?? process.env.PAPER_TRADING_MODE) !==
+      "false",
     defaultPositionSize: parseFloat(
       process.env.MEXC_DEFAULT_POSITION_SIZE || "50"
     ),

--- a/src/services/trading/unified-auto-sniping-orchestrator.ts
+++ b/src/services/trading/unified-auto-sniping-orchestrator.ts
@@ -145,13 +145,17 @@ export class UnifiedAutoSnipingOrchestrator extends BrowserCompatibleEventEmitte
   constructor(config: Partial<OrchestratorConfig> = {}) {
     super();
 
+    const paperTradingFlag =
+      (process.env.MEXC_PAPER_TRADING ?? process.env.PAPER_TRADING_MODE) !==
+      "false";
+
     this.config = {
       enabled: true,
-      paperTradingMode: process.env.MEXC_PAPER_TRADING === "true",
+      paperTradingMode: paperTradingFlag,
       autoInitialize: true,
 
       snipeConfig: {
-        paperTradingMode: process.env.MEXC_PAPER_TRADING === "true",
+        paperTradingMode: paperTradingFlag,
         ...config.snipeConfig,
       },
       patternConfig: {
@@ -165,7 +169,7 @@ export class UnifiedAutoSnipingOrchestrator extends BrowserCompatibleEventEmitte
         ...config.monitorConfig,
       },
       mexcConfig: {
-        paperTradingMode: process.env.MEXC_PAPER_TRADING === "true",
+        paperTradingMode: paperTradingFlag,
         ...config.mexcConfig,
       },
 


### PR DESCRIPTION
## Summary
- update Settings page imports
- manage paper trading state
- add paper trading switch card

## Testing
- `make lint` *(fails: Found 88 errors)*
- `make type-check` *(fails to compile)*
- `make test` *(fails: 67 test files failed)*
- `bun run pre-commit` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684d84c00483308ffae27555ca7336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Paper Trading Mode" toggle in the settings page, allowing users to enable or disable simulated trading.
  * Introduced a new environment variable for configuring paper trading mode.

* **Documentation**
  * Updated the README and environment variable example file to include the new paper trading mode option.

* **Refactor**
  * Improved and centralized the logic for determining paper trading mode based on environment variables, making configuration more flexible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->