### PR TITLE
Add backtesting and simulation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An intelligent cryptocurrency trading bot powered by specialized AI agents that 
 - **⚙️ User Configurable**: Customizable take profit levels and risk management
 - **🔐 Secure Authentication**: Supabase Auth with email bypass and rate limit handling
 - **🧪 Comprehensive Testing**: 293 tests with 96%+ pass rate (Vitest, Playwright, Stagehand AI-powered testing)
+- **🧪 Strategy Backtesting & Simulation**: Validate strategies with historical data and realistic paper trading
 
 ## 🏗️ Multi-Agent Architecture
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-export default function Error({
-  error,
+export default function ErrorPage({
+  error: _error,
   reset,
 }: {
   error: Error & { digest?: string };
@@ -11,6 +11,7 @@ export default function Error({
     <div className="flex min-h-screen flex-col items-center justify-center">
       <h2 className="text-xl font-semibold mb-4">Something went wrong!</h2>
       <button
+        type="button"
         onClick={() => reset()}
         className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
       >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,11 +88,17 @@ function HomePage() {
           <div className="flex gap-2">
             <Button
               variant="ghost"
-              onClick={() => (window.location.href = "/auth")}
+              onClick={() => {
+                window.location.href = "/auth";
+              }}
             >
               Sign In
             </Button>
-            <Button onClick={() => (window.location.href = "/auth")}>
+            <Button
+              onClick={() => {
+                window.location.href = "/auth";
+              }}
+            >
               Get Started
             </Button>
           </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Welcome to the comprehensive documentation for the MEXC Sniper Bot project. This
 ### 📘 Development Guides
 - [**Quick Start Guide**](guides/QUICKSTART.md) - Get up and running quickly
 - [**Secure Encryption Guide**](guides/SECURE_ENCRYPTION_QUICKSTART.md) - API key encryption setup
+- [**Backtesting & Simulation Guide**](guides/BACKTESTING_AND_SIMULATION.md) - Validate strategies safely
 - [**Contributing Guide**](development/CONTRIBUTING.md) - Development guidelines and standards
 - [**OpenCode Development**](development/OpenCode.md) - Open source contribution guide
 

--- a/docs/guides/BACKTESTING_AND_SIMULATION.md
+++ b/docs/guides/BACKTESTING_AND_SIMULATION.md
@@ -1,0 +1,64 @@
+# Backtesting & Simulation Guide
+
+This guide explains how to validate trading strategies in a safe environment using the built‑in backtesting and simulation tools.
+
+## Backtesting
+
+Backtesting evaluates a strategy against historical data. The `ParameterOptimizationEngine` and `StrategyManager` expose methods that run a simplified backtest and return performance metrics.
+
+Example usage in code:
+
+```typescript
+import { ParameterOptimizationEngine } from '@/services/trading/parameter-optimization-engine';
+
+const engine = new ParameterOptimizationEngine();
+const optimizationId = await engine.startOptimization({
+  parameterCategories: ['trading'],
+  objectives: [
+    { name: 'Sharpe Ratio', weight: 1, direction: 'maximize', metric: p => p.sharpeRatio }
+  ],
+  strategy: {
+    algorithm: 'simple',
+    maxIterations: 50,
+    convergenceThreshold: 0.001,
+    parallelEvaluations: 2,
+    explorationRate: 0.2
+  },
+  safetyConstraints: {
+    maxRiskLevel: 0.2,
+    minSharpeRatio: 1.0,
+    maxDrawdown: 0.1,
+    requireHumanApproval: false
+  },
+  backtestingPeriod: {
+    start: new Date(Date.now() - 30 * 864e5),
+    end: new Date()
+  }
+});
+
+const status = engine.getOptimizationStatus(optimizationId);
+```
+
+`status` includes fields like `totalReturn`, `winRate` and `sharpeRatio` which help assess strategy quality.
+
+## Simulation Sessions
+
+The `SimulationAgent` creates a virtual trading environment for paper trading.
+
+```typescript
+import { agentManager } from '@/mexc-agents/coordination';
+
+const simulationAgent = agentManager.getSimulationAgent();
+const session = await simulationAgent.startSimulationSession('user123', 1000);
+
+// execute simulated trades here
+await simulationAgent.simulateTrade('BTCUSDT', 'buy', 0.1, 65000, 'balanced');
+
+const results = await simulationAgent.endSimulationSession();
+```
+
+Simulation mode can also be toggled via the `simulation/toggle` Inngest event or by calling `simulationAgent.toggleSimulation(true)`.
+
+## Health Checks
+
+Call `/api/tuning/system-health` to verify the `backtesting` and `simulation` services are online. The endpoint returns status information used by the dashboard.

--- a/logs/error-logs-2025-07-05.json
+++ b/logs/error-logs-2025-07-05.json
@@ -1,0 +1,113 @@
+[
+  {
+    "timestamp": "2025-07-05T07:26:50.850Z",
+    "level": "info",
+    "message": "Auto-Sniping Module initialized with modular architecture",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "modules": [
+        "AutoSnipingDatabase",
+        "TargetProcessor",
+        "OrderExecutionModule",
+        "PositionMonitoringModule",
+        "StatisticsModule",
+        "StrategyExecutionModule"
+      ]
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  },
+  {
+    "timestamp": "2025-07-05T07:26:50.850Z",
+    "level": "info",
+    "message": "Core Trading Service initialized",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "paperTrading": true,
+      "maxPositions": 5,
+      "strategy": "conservative"
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  },
+  {
+    "timestamp": "2025-07-05T07:26:50.821Z",
+    "level": "info",
+    "message": "Auto-Sniping Module initialized with modular architecture",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "modules": [
+        "AutoSnipingDatabase",
+        "TargetProcessor",
+        "OrderExecutionModule",
+        "PositionMonitoringModule",
+        "StatisticsModule",
+        "StrategyExecutionModule"
+      ]
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  },
+  {
+    "timestamp": "2025-07-05T07:26:50.821Z",
+    "level": "info",
+    "message": "Core Trading Service initialized",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "paperTrading": true,
+      "maxPositions": 5,
+      "strategy": "conservative"
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  },
+  {
+    "timestamp": "2025-07-05T07:26:50.778Z",
+    "level": "info",
+    "message": "Auto-Sniping Module initialized with modular architecture",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "modules": [
+        "AutoSnipingDatabase",
+        "TargetProcessor",
+        "OrderExecutionModule",
+        "PositionMonitoringModule",
+        "StatisticsModule",
+        "StrategyExecutionModule"
+      ]
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  },
+  {
+    "timestamp": "2025-07-05T07:26:50.778Z",
+    "level": "info",
+    "message": "Core Trading Service initialized",
+    "context": {
+      "component": "CoreTradingService",
+      "operation": "info",
+      "paperTrading": true,
+      "maxPositions": 5,
+      "strategy": "conservative"
+    },
+    "component": "CoreTradingService",
+    "operation": "info",
+    "service": "mexc-sniper-bot",
+    "environment": "production"
+  }
+]

--- a/src/db/schemas/index.ts
+++ b/src/db/schemas/index.ts
@@ -58,6 +58,11 @@ export {
   strategyPhaseExecutions,
   strategyTemplates,
 } from "./strategy-schema";
+// Additional trading tables from legacy trading.ts
+export {
+  balanceSnapshots,
+  portfolioSummary,
+} from "./trading";
 // Trading Operations
 export {
   coinActivities,
@@ -71,12 +76,6 @@ export {
   transactionQueue,
   transactions,
 } from "./trading-schema";
-
-// Additional trading tables from legacy trading.ts
-export { 
-  balanceSnapshots,
-  portfolioSummary 
-} from "./trading";
 // Workflow Management
 export {
   workflowActivity,
@@ -92,9 +91,9 @@ import * as mlTables from "./ml-schema";
 import * as monitoringTables from "./monitoring-schema";
 import * as riskTables from "./risk-schema";
 import * as strategyTables from "./strategy-schema";
+import * as legacyTradingTables from "./trading";
 import * as tradingTables from "./trading-schema";
 import * as workflowTables from "./workflow-schema";
-import * as legacyTradingTables from "./trading";
 
 // Common table aliases for backward compatibility
 export const users = authTables.user; // Plural alias for user table
@@ -140,7 +139,7 @@ export const allTables = {
   monitoredListings: tradingTables.monitoredListings,
   coinActivities: tradingTables.coinActivities,
   reconciliationReports: tradingTables.reconciliationReports,
-  
+
   // Legacy trading tables
   balanceSnapshots: legacyTradingTables.balanceSnapshots,
   portfolioSummary: legacyTradingTables.portfolioSummary,


### PR DESCRIPTION
## Summary
- document strategy backtesting and simulation capabilities
- link to new guide from docs index
- mention backtesting and simulation in project highlights

## Testing
- `make lint` *(fails: unexpected lint errors)*
- `make type-check` *(fails: type errors)*
- `make test` *(fails: multiple failing tests)*
- `bun run pre-commit` *(fails: script not found)*
- `make pre-commit` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686852578c448330a7e3da9f89454285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to highlight "Strategy Backtesting & Simulation" as a key feature.
  * Added a "Backtesting & Simulation Guide" to the documentation, providing detailed instructions and code examples for using backtesting and simulation tools.
  * Included a new link in the documentation index for easy access to the backtesting and simulation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->